### PR TITLE
layout van logo en nav laten overeennkomen met de body

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,10 @@
 </head>
 
 <body>
-    <header>
+    <div class="logo">
         <img src="imgTom/logo_1.png" alt="Keurslager Logo" title="Het logo van de keurslager" height="120" />
+    </div>
+    <nav>
         <div class="menu">
             <ul>
                 <li class="items">
@@ -32,7 +34,7 @@
                 </li>
             </ul>
         </div>
-    </header>
+    </nav>
     <main>
         <section>
             <div class="header">

--- a/styleTom/styleTom.css
+++ b/styleTom/styleTom.css
@@ -1,14 +1,22 @@
 body {
     display: grid;
-    grid-template-areas: "header header header" 
+    grid-template-areas: "logo menu menu" 
                          "asideleft main asideright"
                          "footer footer footer";
     grid-template-columns: 1fr 550px 1fr;
     grid-template-rows: 120px 1fr 38px;
+    grid-column-gap: 10px;
 }
 
-header {
-   grid-area: header; 
+.logo{
+    grid-area: logo;
+    justify-self: end;
+}
+nav {
+   grid-area: menu; 
+}
+nav ul{
+    padding-left: 0;
 }
 main {
    grid-area: main; 


### PR DESCRIPTION
De verdeling van het logo en de navigatie is niet mooi uitgelijnd. Door het logo en de navigatie in aparte gridcellen te zetten, is dit volgens mij opgelost.
Ik zou ook een gutter toevoegen.